### PR TITLE
Fix bash_completion.install step

### DIFF
--- a/scw.rb
+++ b/scw.rb
@@ -22,7 +22,7 @@ class Scw < Formula
  # this file is created and handled by scw
     rm_f "~/.scw-cache.db"
 
-    bash_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/bash/scw"
+    bash_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/bash/scw.bash"
     zsh_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/zsh/_scw"
   end
 


### PR DESCRIPTION
The ```scw``` installation from ```scaleway/scaleway``` tap fails due to incorrect path to bash completions configuration. I'm not sure though, whether this repo is necessary any longer because of working version in ```homebrew-core``` found at [scw.rb](https://github.com/Homebrew/homebrew-core/blob/de1ecc1d981de9d5165ea9e96242c32023d14d7c/Formula/scw.rb). Anyway, the link to this repo can be found at the official [guideline](https://github.com/scaleway/scaleway-cli/tree/8c7c75ebf3349d29fcaf8464daf42a7270dd546d#setup) which I was following when the error occurred:
```bash
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - src/github.com/scaleway/scaleway-cli/contrib/completion/bash/scw
```