### PR TITLE
bump docker-machine-driver-scaleway to v1.6

### DIFF
--- a/docker-machine-driver-scaleway.rb
+++ b/docker-machine-driver-scaleway.rb
@@ -3,8 +3,8 @@ require "language/go"
 class DockerMachineDriverScaleway < Formula
   desc "Docker Machine driver for Scaleway"
   homepage "https://github.com/scaleway/docker-machine-driver-scaleway/"
-  url "https://github.com/scaleway/docker-machine-driver-scaleway/archive/v1.3.tar.gz"
-  sha256 "e30253c38cb3f43e66be2ca6dd9f58da870237002ee7a9a4a57d3a29bf45a0da"
+  url "https://github.com/scaleway/docker-machine-driver-scaleway/archive/v1.6.tar.gz"
+  sha256 "9d27fe10c2169ffa2a7de79d65ce5a682f36ca75e1a98681b93b84b34ed8a22d"
 
   head "https://github.com/scaleway/docker-machine-driver-scaleway.git"
 


### PR DESCRIPTION
Will fix https://github.com/scaleway/docker-machine-driver-scaleway/issues/98

Note that IHO we can delete [the formula defined in `docker-machine-driver-scaleway` repo](https://github.com/scaleway/docker-machine-driver-scaleway/blob/master/contrib/homebrew/docker-machine-driver-scaleway.rb).