### PR TITLE
bump scw to v.1.19

### DIFF
--- a/scw.rb
+++ b/scw.rb
@@ -1,33 +1,30 @@
-require "language/go"
-
 class Scw < Formula
-  desc "Manage BareMetal Servers from Command Line (as easily as with Docker)"
+  desc "Manage BareMetal Servers from command-line (as easily as with Docker)"
   homepage "https://github.com/scaleway/scaleway-cli"
-  url "https://github.com/scaleway/scaleway-cli/archive/v1.12.tar.gz"
-  sha256 "7a23ef6960fe280dd19f8e2e9b0fff6ffaf4b8446ddc7833b530901875652e2e"
-  version "1.12"
-
+  url "https://github.com/scaleway/scaleway-cli/archive/v1.19.tar.gz"
+  sha256 "307bb2a67cd8b8a7fb58524dfe3f65bbba476496c051e289e76f11d0508a0ab7"
   head "https://github.com/scaleway/scaleway-cli.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "57a21449714df68f713fba876e8c2b4a62de751fd48cd51c15b5109d4a6fb74f" => :mojave
+    sha256 "f292e2359a0f203d78598f08c36c333a7e418bdd2da019dcb12b4a662b1d2e36" => :high_sierra
+    sha256 "585ec2a43d879705288fc165ca77f19d027976da976e38e72874b1273128c790" => :sierra
+  end
 
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOBIN"] = buildpath
-    ENV["GO15VENDOREXPERIMENT"] = "1"
     (buildpath/"src/github.com/scaleway/scaleway-cli").install Dir["*"]
 
-    system "go", "build", "-o", "#{bin}/scw", "-v", "-ldflags", "-X  github.com/scaleway/scaleway-cli/pkg/scwversion.GITCOMMIT=homebrew", "github.com/scaleway/scaleway-cli/cmd/scw/"
- # we remove our .scw-cache.db file, to clean the cache of scw
- # this file is created and handled by scw
-    rm_f "~/.scw-cache.db"
+    system "go", "build", "-o", "#{bin}/scw", "-v", "-ldflags",
+           "-X github.com/scaleway/scaleway-cli/pkg/scwversion.GITCOMMIT=homebrew",
+           "github.com/scaleway/scaleway-cli/cmd/scw/"
 
     bash_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/bash/scw.bash"
     zsh_completion.install "src/github.com/scaleway/scaleway-cli/contrib/completion/zsh/_scw"
-  end
-
-  def caveats
-    "Use `scw login` to set up the correct environment to use scaleway-cli."
   end
 
   test do


### PR DESCRIPTION
As we document it in the [scaleway-cli README](https://github.com/scaleway/scaleway-cli/blob/master/README.md) we need to maintain it. (`brew tap scaleway/scaleway`)
It is a copy of the [official formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/scw.rb)

In the future, we could remove the mention of this formula in the [scaleway-cli README](https://github.com/scaleway/scaleway-cli/blob/master/README.md) and deprecated it in favor of [the official one](https://github.com/Homebrew/homebrew-core/blob/master/Formula/scw.rb).